### PR TITLE
Change retention of ignition data from 7 to 60 days

### DIFF
--- a/data-overview/danish.md
+++ b/data-overview/danish.md
@@ -20,8 +20,8 @@ Denne funktion, giver dig et overblik over din bils aktuelle tilstand/ status og
 | Parameter | Formål med behandling | Opbevaring |
 |-----------|-----------------------|------------|
 | Bilens GPS position | Så brugeren kan se hvor bilen er | 1 times historisk data og seneste værdi |
-| Tænding slået til | Anvendes til logikker, som kvalitetssikrer data | 7 dages historisk data og seneste værdi |
-| Tænding slået fra | Anvendes til logikker, som kvalitetssikrer data | 7 dages historisk data og seneste værdi |
+| Tænding slået til | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
+| Tænding slået fra | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
 | Bilens kilometerstand | Så brugeren kan se bilens kilometerstand i app'en | 60 dages historisk data og seneste værdi |
 | Bilens brændstofsniveau | Så brugeren kan se bilens brændstofsniveau i app'en | 7 dages historisk data og seneste værdi |
 | Bilens låsestatus | Så brugeren kan se i app'en om bilen er låst eller ulåst | 7 dages historisk data og seneste værdi |

--- a/data-overview/english.md
+++ b/data-overview/english.md
@@ -20,8 +20,8 @@ This feature gives you an overview of the current satus of your car / errors and
 | Parameter | Purpose of data processing | Storage |
 |-----------|-----------------------|------------|
 | Car GPS position | So the user can see where the car is | 1 hour historical data and most recent value |
-| Ignition on | Used for logic, which quality assures data | 7 days historical data and most recent value |
-| Ignition off | Used for logic, which quality assures data | 7 days historical data and most recent value |
+| Ignition on | Used for logic, which quality assures data | 60 days historical data and most recent value |
+| Ignition off | Used for logic, which quality assures data | 60 days historical data and most recent value |
 | Car mileage | So the user can see the car's mileage in the app | 60 days historical data and most recent value |
 | Car fuel level | So the user can see the car's fuel level in the app | 7 days historical data and most recent value |
 | Car lock status | So the user can see in the app if the car is locked or unlocked | 7 days historical data and most recent value |


### PR DESCRIPTION
This is done to support service data reminders. In order to make sure that service data is not marked as too old for users on vacation or cases where the car is not used and hence do not send data, we need to check the ignition to see if the car has been driven for this period.