### PR TITLE
Fuel data retention 60 days

### DIFF
--- a/data-overview/danish.md
+++ b/data-overview/danish.md
@@ -8,9 +8,9 @@ Denne funktion giver dig mulighed for at få historik over bilens kørte ture. D
 |-----------|-----------------------|------------|
 | Bilens GPS position | Så brugeren kan se bilens rute på et kort | Gemmes indtil brugeren anmoder om sletning af turen |
 | Bilens retning | Så brugeren kan se bilens rute på et kort, anvendes til at kvalitetsoptimere rutevisning | Gemmes indtil brugeren anmoder om sletning af turen |
-| Bilens brændstofniveau | Så brugeren kan se bilens estimeret brændstofforbrug | 8 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
+| Bilens brændstofniveau | Så brugeren kan se bilens estimeret brændstofforbrug | 60 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
 | Bilens kilometerstand | Så brugeren kan se antal kørte kilometer for hver tur | 60 dages historisk data. Udregnet distance på ture gemmes indtil brugeren anmoder om sletning af turen |
-| Bilens brændstofforbrug | Så brugeren kan se bilens estimeret brændstofforbrug for hver tur | 8 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
+| Bilens brændstofforbrug | Så brugeren kan se bilens estimeret brændstofforbrug for hver tur | 60 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
 | Køreturen i tid | Så brugeren kan se køreturens varighed | Gemmes indtil brugeren anmoder om sletning af turen |
 
 ## Aktuel status på din bil
@@ -23,7 +23,7 @@ Denne funktion, giver dig et overblik over din bils aktuelle tilstand/ status og
 | Tænding slået til | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
 | Tænding slået fra | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
 | Bilens kilometerstand | Så brugeren kan se bilens kilometerstand i app'en | 60 dages historisk data og seneste værdi |
-| Bilens brændstofniveau | Så brugeren kan se bilens brændstofniveau i app'en | 7 dages historisk data og seneste værdi |
+| Bilens brændstofniveau | Så brugeren kan se bilens brændstofniveau i app'en | 60 dages historisk data og seneste værdi |
 | Bilens låsestatus | Så brugeren kan se i app'en om bilen er låst eller ulåst | 7 dages historisk data og seneste værdi |
 | Bilens serviceinterval i dage | Bruges til beregning, så brugeren kan se hvornår bilen skal til service igen | 60 dages historisk data og seneste værdi |
 | Bilens serviceinterval i kilometer | Bruges til beregning, så brugeren kan se hvornår bilen skal til service igen | 60 dages historisk data og seneste værdi |

--- a/data-overview/danish.md
+++ b/data-overview/danish.md
@@ -8,9 +8,9 @@ Denne funktion giver dig mulighed for at få historik over bilens kørte ture. D
 |-----------|-----------------------|------------|
 | Bilens GPS position | Så brugeren kan se bilens rute på et kort | Gemmes indtil brugeren anmoder om sletning af turen |
 | Bilens retning | Så brugeren kan se bilens rute på et kort, anvendes til at kvalitetsoptimere rutevisning | Gemmes indtil brugeren anmoder om sletning af turen |
-| Bilens brændstofsniveau | Så brugeren kan se bilens estimeret brændstofsforbrug | 8 dages historisk data. Udregnet brændstofsforbrug gemmes indtil brugeren anmoder om sletning af turen |
+| Bilens brændstofniveau | Så brugeren kan se bilens estimeret brændstofforbrug | 8 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
 | Bilens kilometerstand | Så brugeren kan se antal kørte kilometer for hver tur | 60 dages historisk data. Udregnet distance på ture gemmes indtil brugeren anmoder om sletning af turen |
-| Bilens brændstofsforbrug | Så brugeren kan se bilens estimeret brændstofsforbrug for hver tur | 8 dages historisk data. Udregnet brændstofsforbrug gemmes indtil brugeren anmoder om sletning af turen |
+| Bilens brændstofforbrug | Så brugeren kan se bilens estimeret brændstofforbrug for hver tur | 8 dages historisk data. Udregnet brændstofforbrug gemmes indtil brugeren anmoder om sletning af turen |
 | Køreturen i tid | Så brugeren kan se køreturens varighed | Gemmes indtil brugeren anmoder om sletning af turen |
 
 ## Aktuel status på din bil
@@ -23,7 +23,7 @@ Denne funktion, giver dig et overblik over din bils aktuelle tilstand/ status og
 | Tænding slået til | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
 | Tænding slået fra | Anvendes til logikker, som kvalitetssikrer data | 60 dages historisk data og seneste værdi |
 | Bilens kilometerstand | Så brugeren kan se bilens kilometerstand i app'en | 60 dages historisk data og seneste værdi |
-| Bilens brændstofsniveau | Så brugeren kan se bilens brændstofsniveau i app'en | 7 dages historisk data og seneste værdi |
+| Bilens brændstofniveau | Så brugeren kan se bilens brændstofniveau i app'en | 7 dages historisk data og seneste værdi |
 | Bilens låsestatus | Så brugeren kan se i app'en om bilen er låst eller ulåst | 7 dages historisk data og seneste værdi |
 | Bilens serviceinterval i dage | Bruges til beregning, så brugeren kan se hvornår bilen skal til service igen | 60 dages historisk data og seneste værdi |
 | Bilens serviceinterval i kilometer | Bruges til beregning, så brugeren kan se hvornår bilen skal til service igen | 60 dages historisk data og seneste værdi |
@@ -56,7 +56,7 @@ Denne funktion, giver dig et overblik over din bils aktuelle tilstand/ status og
 
 ## Teknisk hjælp af dit foretrukne værksted
 
-Denne funktion sikrer at du kan få den rette rådgiving fra dit foretrukne værksted baseret på data direkte fra bilen
+Denne funktion sikrer at du kan få den rette rådgivning fra dit foretrukne værksted baseret på data direkte fra bilen
 
 | Parameter | Formål med behandling | Opbevaring |
 |-----------|-----------------------|------------|
@@ -88,7 +88,7 @@ Denne funktion sikrer at du kan få den rette rådgiving fra dit foretrukne vær
 | Brugerens telefonnummer | Så brugerens foretrukne værksted har kontaktoplysninger | Gemmes indtil brugeren anmoder om sletning |
 | Brugerens email | Så brugerens foretrukne værksted har kontaktoplysninger | Gemmes indtil brugeren anmoder om sletning |
 | Bilens stelnummer | Så brugerens foretrukne værksted kan identificere bilen | Gemmes indtil brugeren anmoder om sletning |
-| Bilens registeringsnummer | Så brugerens foretrukne værksted kan identificere bilen | Gemmes indtil brugeren anmoder om sletning |
+| Bilens registreringsnummer | Så brugerens foretrukne værksted kan identificere bilen | Gemmes indtil brugeren anmoder om sletning |
 | Bruger ID | Så brugerens foretrukne værksted kan identificere bilen | Gemmes indtil brugeren anmoder om sletning |
 | OBD-enheds ID  Så brugerens foretrukne værksted kan identificere bilen | Gemmes indtil brugeren anmoder om sletning |
 | Bilens modelinformation | Så brugerens foretrukne værksted kan rådgive brugeren og booke korrekt service eller reparation hvis det er nødvendigt | Gemmes indtil brugeren anmoder om sletning |
@@ -105,7 +105,7 @@ Data, som er teknisk nødvendige for at garantere sikker og effektiv udlæsning 
 |-----------|-----------------------|------------|
 | Bilens stelnummer | Anvendes til at sikre at den korrekte software indlæses på OBD-enheden | Altid |
 | Bilens tekniske konfiguration | Anvendes til at sikre at den korrekte software indlæses på OBD-enheden | Altid |
-| Scanning af bilens elektroniske configuration | Anvendes til at sikre at den korrekte software indlæses på OBD-enheden | Altid |
+| Scanning af bilens elektroniske konfiguration | Anvendes til at sikre at den korrekte software indlæses på OBD-enheden | Altid |
 | CAN-Bus rå-data | Anvendes til fejlfinding | Altid |
 | CAN-Bus aktivitet on/off | Anvendes til kvalitetssikring af indsamlet data | 7 dages historisk data og seneste værdi |
 
@@ -118,7 +118,7 @@ Brugeren får konkrete informationer om hændelser og konditioner for sine ture 
 | Hastighed (med position) | Hastighed er kendt som den aller vigtigste faktor for trafiksikkerhed. Det er nødvendigt at bruge hastighed til at advisere brugere om, hvordan og hvor de kan forbedre deres kørsel | Gemmes indtil brugeren anmoder om sletning. Værdier +130 Km/h er reduceret til 130 km/h da hastigheder over dette niveau ikke er relevant. |
 | Brug af vinduesviskere | Kørsel i regn er associeret med risiko for akvaplaning og mange ulykker hvert år. Det er nødvendigt at anvende brug af vinduesviskere til at detektere om en bil kører i regn og derfor er udsat for højere risiko for uheld | Gemmes indtil brugeren anmoder om sletning |
 | Udendørs temperatur | Kørsel i kolde temperaturer er associeret med glatte og potentielt isede forhold. Glatte forhold grundet koldt vejr er associeret med adskillige uheld hvert år. Udendørs temperatur er en indikator for glatte forhold. Derfor er det nødvendigt at anvende temperatur for at advisere brugere om, hvordan de kan forbedre deres kørsel | Gemmes indtil brugeren anmoder om sletning |
-| Køretøj accelleration over 0.2G (alle retninger), med position | Pludselige og ofte ændringer i retning (forhøjelse/nedsættelse af hastighed såvel som sving) er portentielt risikofyldte handlinger foretaget af chaufføren. Jævn kørsel er ofte sikker kørsel, derfor kan accelerationer anvendes til at rådgive brugere om, hvor og de kan forbedre deres kørsel | Gemmes indtil brugeren anmoder om sletning |
+| Køretøj acceleration over 0.2G (alle retninger), med position | Pludselige og ofte ændringer i retning (forhøjelse/nedsættelse af hastighed såvel som sving) er potentielt risikofyldte handlinger foretaget af chaufføren. Jævn kørsel er ofte sikker kørsel, derfor kan accelerationer anvendes til at rådgive brugere om, hvor og de kan forbedre deres kørsel | Gemmes indtil brugeren anmoder om sletning |
 | ESP deaktiveringslampe | Bilens ESP-system sikrer stabilitet, hvis der mistes friktion mod underlaget for et eller flere hjul. Slås ESP-systemet fra udgør det en potentielt signifikant risiko for kørsel. Derfor er det nødvendigt at advisere brugere, som har slået ESP systemet fra om, hvordan de kan forbedre deres kørsel | Gemmes indtil brugeren anmoder om sletning |
 | ESP aktiveringslampe | Aktivering af ESP systemet indikerer glat føre og derfor mindre sikre kørselsforhold. Derfor er det nødvendigt at bero på signaler fra ESP-systemet for at advisere brugere om, hvordan de kan køre sikrere i vådt føre | Gemmes indtil brugeren anmoder om sletning |
 | Langt lys aktiveret | Kørsel i mørke forhold er associeret med højere risiko i forhold til kørsel i dagslys eller belyste veje. Især kørsel på landeveje ved skumring og nat udgør højere risiko end kørsel i dagslys. Brug af det lange lys er en indikator på kørsel i mørke. Derfor er det nødvendigt at anvende brugen af langt lys til at advisere brugere om at forbedre sin kørsel i mørke forhold | Gemmes indtil brugeren anmoder om sletning |

--- a/data-overview/english.md
+++ b/data-overview/english.md
@@ -8,9 +8,9 @@ My Trips allows you to get a history of your cars trips. You can see where you h
 |-----------|-----------------------|------------|
 | Car GPS position | So the user can see the car's route on a map | Saved until user requests deletion of trip |
 | Direction of car | So the user can see the car's route on a map, used to optimize route viewing | Saved until user requests deletion of trip |
-| Car fuel level | So the user can see the car's estimated fuel consumption | 8 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
+| Car fuel level | So the user can see the car's estimated fuel consumption | 60 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
 | Car mileage | So the user can see the number of kilometers traveled for each trip | 60 days historical data. Calculated distance on trip is saved until user requests deletion of trip |
-| Car fuel consumption | So the user can see the car's estimated fuel consumption for each trip | 8 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
+| Car fuel consumption | So the user can see the car's estimated fuel consumption for each trip | 60 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
 | Drive in time | So the user can see the duration of the trip | Saved until user requests deletion of trip |
 
 ## Current status of your car
@@ -23,7 +23,7 @@ This feature gives you an overview of the current status of your car / errors an
 | Ignition on | Used for logic, which quality assures data | 60 days historical data and most recent value |
 | Ignition off | Used for logic, which quality assures data | 60 days historical data and most recent value |
 | Car mileage | So the user can see the car's mileage in the app | 60 days historical data and most recent value |
-| Car fuel level | So the user can see the car's fuel level in the app | 7 days historical data and most recent value |
+| Car fuel level | So the user can see the car's fuel level in the app | 60 days historical data and most recent value |
 | Car lock status | So the user can see in the app if the car is locked or unlocked | 7 days historical data and most recent value |
 | Car service interval in days | Used for calculation so that the user can see when the car needs service again | 60 days historical data and most recent value |
 | Car service interval in kilometers | Used for calculation so that the user can see when the car needs service again | 60 days historical data and most recent value |

--- a/data-overview/english.md
+++ b/data-overview/english.md
@@ -10,12 +10,12 @@ My Trips allows you to get a history of your cars trips. You can see where you h
 | Direction of car | So the user can see the car's route on a map, used to optimize route viewing | Saved until user requests deletion of trip |
 | Car fuel level | So the user can see the car's estimated fuel consumption | 8 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
 | Car mileage | So the user can see the number of kilometers traveled for each trip | 60 days historical data. Calculated distance on trip is saved until user requests deletion of trip |
-| Car fuel consumtion | So the user can see the car's estimated fuel consumption for each trip | 8 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
+| Car fuel consumption | So the user can see the car's estimated fuel consumption for each trip | 8 days historical data. Calculated fuel consumption is saved until user requests deletion of trip |
 | Drive in time | So the user can see the duration of the trip | Saved until user requests deletion of trip |
 
 ## Current status of your car
 
-This feature gives you an overview of the current satus of your car / errors and time to next service and oil change
+This feature gives you an overview of the current status of your car / errors and time to next service and oil change
 
 | Parameter | Purpose of data processing | Storage |
 |-----------|-----------------------|------------|
@@ -87,14 +87,14 @@ This feature ensures that you get the right advice from your preferred workshop 
 | User full name | So the user's preferred workshop has contact information | Saved until the user requests deletion |
 | User phone number | So the user's preferred workshop has contact information | Saved until the user requests deletion |
 | User email | So the user's preferred workshop has contact information | Saved until the user requests deletion |
-| Car chasis number | So the user's preferred workshop can identify the car | Saved until the user requests deletion |
+| Car chassis number | So the user's preferred workshop can identify the car | Saved until the user requests deletion |
 | Car registration number | So the user's preferred workshop can identify the car | Saved until the user requests deletion |
 | User ID | So the user's preferred workshop can identify the car | Saved until the user requests deletion |
 | OBD device ID  So the user's preferred workshop can identify the car | Saved until the user requests deletion |
 | Car model information | So the user's preferred workshop can advise the user and book the correct service or repair if necessary | Saved until the user requests deletion |
 | User chat history with preferred workshop | So the user's preferred workshop can get an insight into the car's history and previous dialogue to best guide the user | Saved until the user requests deletion |
-| GPS status ok (yes/no) | So user's preferred workshop can ensure that there is no fault with the OBD device in the car | 7 days historical data and most recent value |
-| GPRS status ok (yes/no) | So user's preferred workshop can ensure that there is no fault with the OBD device in the car | 7 days historical data and most recent value |
+| GPS status OK (yes/no) | So user's preferred workshop can ensure that there is no fault with the OBD device in the car | 7 days historical data and most recent value |
+| GPRS status OK (yes/no) | So user's preferred workshop can ensure that there is no fault with the OBD device in the car | 7 days historical data and most recent value |
 | OBD device activated (yes/no) | So user's preferred workshop can ensure that there is no fault with the OBD device in the car | Saved until the user requests deletion |
 
 ## Ancillary data
@@ -103,23 +103,23 @@ Data that is technically necessary to ensure safe and efficient reading of data 
 
 | Parameter | Purpose of data processing | Storage |
 |-----------|-----------------------|------------|
-| Car chasis number | Used to ensure that the correct software is loaded on the OBD device | Always |
+| Car chassis number | Used to ensure that the correct software is loaded on the OBD device | Always |
 | Car technical configuration | Used to ensure that the correct software is loaded on the OBD device | Always |
-| Scan of car's electronical configuration | Used to ensure that the correct software is loaded on the OBD device | Always |
+| Scan of car's electronic configuration | Used to ensure that the correct software is loaded on the OBD device | Always |
 | CAN-Bus raw data | Used for troubleshooting | Always |
 | CAN-Bus activity on/off | Used for quality assurance of collected data | 7 days historical data and most recent value |
 
 ## Driving events
 
-This feature gives you information about incidents and conditions for your car's trips shown in your app and summed up in benchmarks where you can track your improvements regarding safe driving. Collected data is shown in the app and used to provide you concrete areas of imporvement to be a safer driver.
+This feature gives you information about incidents and conditions for your car's trips shown in your app and summed up in benchmarks where you can track your improvements regarding safe driving. Collected data is shown in the app and used to provide you concrete areas of improvement to be a safer driver.
 
 | Parameter | Purpose of data processing | Storage |
 |-----------|-----------------------|------------|
 | Speed (with position) | Speed is known to be the single most important component of traffic accidents. It is necessary rely on speed to advise users on how and where to improve their driving | Kept until the user requests deletion. Values +130 Km/h are reduced to 130 km/h as speeds above this level is not relevant |
 | Use of wind wipers | Driving in rain is associated with risks of aqua planing and many accidents every year. It is necessary to rely on use of wind wipers to detect if car is driving in rain, and therefore more risky | Kept until the user requests deletion |
 | Outside temperature | Driving at cold temperatures is associated with slippery and potentially icy conditions. Slippery conditions because of cold weather is associated with multiple accidents every year. Outside temperature is an indicator for slippery conditions. Therefore, it is necessary rely on temperature to advise users on how to improve their driving | Kept until the user requests deletion |
-| Vehicle accelleration above 0.2G (any direction), with position | Sudden and often change of direction (increase/decrease of speed as well as turning) are risky actions by the driver. Smooth driving is safe driving therefore accelleration events must be used to advice drivers on where  and when they make mistakes | Kept until the user requests deletion |
+| Vehicle acceleration above 0.2G (any direction), with position | Sudden and often change of direction (increase/decrease of speed as well as turning) are risky actions by the driver. Smooth driving is safe driving therefore acceleration events must be used to advice drivers on where  and when they make mistakes | Kept until the user requests deletion |
 | ESP deactivation light | The ESP-system of the vehicle ensures stability should it loose traction on one or more wheels. Disabling the ESP-system poses a very significant risks for driving. Therefore, It is necessary to advise users who disable the ESP-system users on how to improve their driving | Kept until the user requests deletion |
 | ESP activation light | Activation of the ESP-system indicates slippery surface, and therefore more risky driving conditions. Therefore, It is necessary to rely on signals from the ESP-system to advise users on how to take better care when driving in slippery conditions | Kept until the user requests deletion |
 | High beam activated | Driving in dark conditions is associated with higher risk than driving in day light or where street lights are installed. Country roads are especially at dusk and at night much more risky to drive than at daylight. Use of high beam is an indicator for driving on dark. Therefore, It is necessary to rely on use of high beam to advise users to slow down in dark conditions | Kept until the user requests deletion |
-| Fog lights activated | Driving in foggy conditions is hazardous and the cause of many accidation every year. Use of fog lights is an indicator for foggy conditions. Therefore, It is necessary to rely on use of fog lights to advise users on safer driving in foggy conditions | Kept until the user requests deletion |
+| Fog lights activated | Driving in foggy conditions is hazardous and the cause of many accidents every year. Use of fog lights is an indicator for foggy conditions. Therefore, It is necessary to rely on use of fog lights to advise users on safer driving in foggy conditions | Kept until the user requests deletion |


### PR DESCRIPTION
This change is needed to support the calculation of fuel tank sizes for each car based on historical data. The current 7/8 days retention makes it unlikely that the dataset includes the fuel max level of each car. Having good fuel tank estimates provides a foundation for calculating the fuel level based on fuel levels provided in pct.

Additionally, this PR fixes some spelling errors in the original text.  