### PR TITLE
fix(): spacing for escaping proto block code

### DIFF
--- a/push-v2.md
+++ b/push-v2.md
@@ -1385,6 +1385,7 @@ message CanNextServiceKm {
 Represents a car service booking record with the status of the booking and the appointment date.
 - See [BookingStatus](#bookingstatus) for possible `booking_status` values
 - See [BookingReasonKey](#bookingreasonkey) for possible `reason_key` values
+
 ```proto
 syntax = "proto3";
 


### PR DESCRIPTION
[sc-128881][skip-sc]

Looks like the spacing is off: 
<img width="907" alt="image" src="https://github.com/user-attachments/assets/7269e82f-3dee-4882-96b0-a584a2b0bec6" />
